### PR TITLE
Bugfix: Adjust viewport on window resize

### DIFF
--- a/odrviewer/viewer.js
+++ b/odrviewer/viewer.js
@@ -7498,16 +7498,17 @@ var OdrViewer = (() => {
           if (!win) return;
           if (GLFW.active.id == win.id) {
             if (width == screen.width && height == screen.height) {
-              Browser.requestFullscreen()
+              Browser.requestFullscreen();
             } else {
               Browser.exitFullscreen();
               Browser.setCanvasSize(width, height);
               win.width = width;
-              win.height = height
+              win.height = height;
+              _glViewport(0, 0, width, height);
             }
           }
           if (!win.windowSizeFunc) return;
-          getWasmTableEntry(win.windowSizeFunc)(win.id, width, height)
+          getWasmTableEntry(win.windowSizeFunc)(win.id, width, height);
         },
         createWindow: function (width, height, title, monitor, share) {
           var i, id;


### PR DESCRIPTION
Hi Matteo,

first of all, thank you for the OpenDRIVE Viewer extension for Visual Studio Code. I've been using the online OpenDRIVE viewer for years in my professional work and I think integrating it directly into Visual Studio Code with offline capabilities is a fantastic idea.

However, while using the extension, I noticed that the viewport doesn't adjust when the window size is changed (this behavior also occurs on the official OpenDRIVE Viewer website, and I'll create an issue in that repository as well). This PR, on the other hand, specifically addresses the problem in the Visual Studio Code extension by ensuring that the viewport is properly adjusted.

Thank you for considering this fix!

Best regards,
Fabian